### PR TITLE
Resolved body-parser deprecation messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_STORE

--- a/server.js
+++ b/server.js
@@ -10,7 +10,10 @@ app.get("/", function (req, res) {
 });
 
 app.use(methodOverride());
-app.use(bodyParser());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
 app.use(express.static(__dirname + '/public'));
 app.use(errorHandler({
   dumpExceptions: true,


### PR DESCRIPTION
Hey,

I love the simplicity of this repo. I use it quite a bit for a .sh script I run. There are body-parser errors as of Express 4. They are extremely easy to fix, thankfully.

``` bash
body-parser deprecated bodyParser: use individual json/urlencoded middlewares server.js:13:9
body-parser deprecated urlencoded: explicitly specify "extended: true" for extended parsing node_modules/body-parser/index.js:74:29
```

I updated the server.js file to use the new version. I also added a .gitignore file to ignore the node modules in case someone else wants to fork this repo.
